### PR TITLE
bpf: properly clear ctx->{log, log_size} after dumping bpf errors

### DIFF
--- a/lib/bpf.c
+++ b/lib/bpf.c
@@ -1304,6 +1304,8 @@ bpf_dump_error(struct bpf_elf_ctx *ctx, const char *format, ...)
 	if (bpf_log_has_data(ctx)) {
 		if (ctx->verbose) {
 			fprintf(stderr, "%s\n", ctx->log);
+
+			memset(ctx->log, 0, ctx->log_size);
 		} else {
 			unsigned int off = 0, len = strlen(ctx->log);
 
@@ -1313,9 +1315,11 @@ bpf_dump_error(struct bpf_elf_ctx *ctx, const char *format, ...)
 					off);
 			}
 			fprintf(stderr, "%s\n", ctx->log + off);
-		}
 
-		memset(ctx->log, 0, ctx->log_size);
+			free(ctx->log);
+			ctx->log = NULL;
+			ctx->log_size = 0;
+		}
 	}
 }
 


### PR DESCRIPTION
When the bpf(BPF_PROG_LOAD, ) or bpf(BPF_BTF_LOAD, ) syscalls return an
error, the loader logic will invoke them again with the verifier logs
enabled, even if the verbose flag was not set.

When that happens, we now reset to 0 ctx->log and ctx->log_size in
bpf_dump_error() to ensure that the subsequent bpf syscall invocations
will not turn on the verbose verifier logs if the verbose flag was not
set.

Reported-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Gilberto Bertin <gilberto@isovalent.com>