### PR TITLE
Show mask of output mark

### DIFF
--- a/ip/ipxfrm.c
+++ b/ip/ipxfrm.c
@@ -643,6 +643,10 @@ static void xfrm_output_mark_print(struct rtattr *tb[], FILE *fp)
 	__u32 output_mark = rta_getattr_u32(tb[XFRMA_OUTPUT_MARK]);
 
 	fprintf(fp, "output-mark 0x%x", output_mark);
+	if (tb[XFRMA_SET_MARK_MASK]) {
+		__u32 mask = rta_getattr_u32(tb[XFRMA_SET_MARK_MASK]);
+		fprintf(fp, "/0x%x", mask);
+	}
 }
 
 int xfrm_parse_mark(struct xfrm_mark *mark, int *argcp, char ***argvp)


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/14381 will make use of the xfrm output mark's mask. This pull request cherry picks the appropriate commit from upstream to be able to show the mask in `ip xfrm state`:

Before:
```
$ sudo ip xfrm s
src fd00::72 dst fd00::1d1
	proto esp spi 0x00000006 reqid 1 mode tunnel
	replay-window 0 
	mark 0x6e00/0xff00 output-mark 0xe00
	aead rfc4106(gcm(aes)) 0x44434241343332312423222114131211f4f3f2f1 128
	anti-replay context: seq 0x0, oseq 0x69, bitmap 0x00000000
	sel src ::/0 dst ::/0
```
After:
```
$ sudo ip xfrm s
src fd00::72 dst fd00::1d1
	proto esp spi 0x00000006 reqid 1 mode tunnel
	replay-window 0 
	mark 0x6e00/0xff00 output-mark 0xe00/0xf00
	aead rfc4106(gcm(aes)) 0x44434241343332312423222114131211f4f3f2f1 128
	anti-replay context: seq 0x0, oseq 0x6f, bitmap 0x00000000
	sel src ::/0 dst ::/0
...
```

/cc @jrfastab 