### PR TITLE
Set mask of output mark

### DIFF
--- a/ip/xfrm_state.c
+++ b/ip/xfrm_state.c
@@ -61,7 +61,7 @@ static void usage(void)
 	fprintf(stderr, "        [ flag FLAG-LIST ] [ sel SELECTOR ] [ LIMIT-LIST ] [ encap ENCAP ]\n");
 	fprintf(stderr, "        [ coa ADDR[/PLEN] ] [ ctx CTX ] [ extra-flag EXTRA-FLAG-LIST ]\n");
 	fprintf(stderr, "        [ offload [dev DEV] dir DIR ]\n");
-	fprintf(stderr, "        [ output-mark OUTPUT-MARK ]\n");
+	fprintf(stderr, "        [ output-mark OUTPUT-MARK [ mask MASK ] ]\n");
 	fprintf(stderr, "Usage: ip xfrm state allocspi ID [ mode MODE ] [ mark MARK [ mask MASK ] ]\n");
 	fprintf(stderr, "        [ reqid REQID ] [ seq SEQ ] [ min SPI max SPI ]\n");
 	fprintf(stderr, "Usage: ip xfrm state { delete | get } ID [ mark MARK [ mask MASK ] ]\n");
@@ -323,7 +323,7 @@ static int xfrm_state_modify(int cmd, unsigned int flags, int argc, char **argv)
 		struct xfrm_user_sec_ctx sctx;
 		char    str[CTX_BUF_SIZE];
 	} ctx = {};
-	__u32 output_mark = 0;
+	struct xfrm_mark output_mark = {0, 0};
 
 	while (argc > 0) {
 		if (strcmp(*argv, "mode") == 0) {
@@ -441,8 +441,18 @@ static int xfrm_state_modify(int cmd, unsigned int flags, int argc, char **argv)
 			}
 		} else if (strcmp(*argv, "output-mark") == 0) {
 			NEXT_ARG();
-			if (get_u32(&output_mark, *argv, 0))
+			if (get_u32(&output_mark.v, *argv, 0))
 				invarg("value after \"output-mark\" is invalid", *argv);
+			if (argc > 1) {
+				NEXT_ARG();
+				if (strcmp(*argv, "mask") == 0) {
+					NEXT_ARG();
+					if (get_u32(&output_mark.m, *argv, 0))
+						invarg("mask value is invalid\n", *argv);
+				} else {
+					PREV_ARG();
+				}
+			}
 		} else {
 			/* try to assume ALGO */
 			int type = xfrm_algotype_getbyname(*argv);
@@ -726,8 +736,11 @@ static int xfrm_state_modify(int cmd, unsigned int flags, int argc, char **argv)
 		}
 	}
 
-	if (output_mark)
-		addattr32(&req.n, sizeof(req.buf), XFRMA_OUTPUT_MARK, output_mark);
+	if (output_mark.v)
+		addattr32(&req.n, sizeof(req.buf), XFRMA_OUTPUT_MARK, output_mark.v);
+
+	if (output_mark.m)
+		addattr32(&req.n, sizeof(req.buf), XFRMA_SET_MARK_MASK, output_mark.m);
 
 	if (rtnl_open_byproto(&rth, 0, NETLINK_XFRM) < 0)
 		exit(1);

--- a/man/man8/ip-xfrm.8
+++ b/man/man8/ip-xfrm.8
@@ -60,7 +60,9 @@ ip-xfrm \- transform configuration
 .RB "[ " extra-flag
 .IR EXTRA-FLAG-LIST " ]"
 .RB "[ " output-mark
-.IR OUTPUT-MARK " ]"
+.IR OUTPUT-MARK
+.RB "[ " mask
+.IR MASK " ] ]"
 
 .ti -8
 .B "ip xfrm state allocspi"


### PR DESCRIPTION
In https://github.com/cilium/iproute2/pull/6, I backported a commit from upstream to be able to show the output mask in `ip xfrm state`. It is however also useful to be able to set that mask for quick test and to replace entries manually. This pull request cherry picks the appropriate commit from upstream to that end.