### PR TITLE
ipmroute: Prevent overlapping storage of `filter` global

### DIFF
--- a/ip/ipmroute.c
+++ b/ip/ipmroute.c
@@ -44,7 +44,7 @@ static void usage(void)
 	exit(-1);
 }
 
-struct rtfilter {
+static struct rtfilter {
 	int tb;
 	int af;
 	int iif;


### PR DESCRIPTION
[ upstream commit 578cadcc68035943062d74507c3b7989741b353f ]

This variable has the same name as `struct xfrm_filter filter` in
ip/ipxfrm.c, but overrides that definition since `struct rtfilter`
is larger.

This is visible when built with -Wl,--warn-common in LDFLAGS:

	/usr/bin/ld: ipxfrm.o: warning: common of `filter' overridden by larger common from ipmroute.o

Signed-off-by: Michael Forney <mforney@mforney.org>
Signed-off-by: Stephen Hemminger <stephen@networkplumber.org>